### PR TITLE
add_basic_authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,16 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,14 +3,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   private
-
-  def production?
-    Rails.env.production?
-  end
-
+  
   def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    if Rails.env.production?
+      authenticate_or_request_with_http_basic do |username, password|
+        username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      end
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   private
-  if Rails.env.production?
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,12 +3,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   private
-
-  def production?
-    Rails.env.production?
-  end
-
-  def basic_auth
+  if Rails.env.production?
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,6 @@
 server '13.113.2.237', user: 'ec2-user', roles: %w{app db web}
-
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.


### PR DESCRIPTION
# WHAT
本番環境のみ、Basic認証を導入して閲覧できるユーザーを制限します。

# WHY
現在はIPアドレスを知っている人なら世界中の誰でもアクセスできてしまい、
誤解が生じる可能性があるため。

