### PR TITLE
商品出品ページの修正

### DIFF
--- a/app/assets/stylesheets/products/listing.scss
+++ b/app/assets/stylesheets/products/listing.scss
@@ -207,21 +207,31 @@
         }
       }
     }
-    &__last{
+  }
+}
+.listing__last{
+  background-color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  height: auto;
+  &__box{
+    border-top: 1px solid #eee;
+    background-color: white;
+    width: 700px;
+    margin: 0 auto;
+    &__attention{
       padding: 40px;
-      border-top: 1px solid #eee;
-      &__attention{
-        font-size: 14px;
-        a{
-          color: #0099e8;
-          text-decoration: none;
-        }
-        a:hover{
-          @include a-tag-hover;
-        }
+      font-size: 14px;
+      a{
+        color: #0099e8;
+        text-decoration: none;
       }
+      a:hover{
+        @include a-tag-hover;
+      }
+    
       .btn-default{
-        margin: 40px 0 0;
+        margin: 40px auto;
         display: block;
         width: 100%;
         line-height: 48px;
@@ -248,6 +258,7 @@
     }
   }
 }
+
 .listing-footer{
   height: 220px;
   background-color: #f5f5f5;

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,4 +1,5 @@
 .listing
   = render "shared/new-header"
-  = render "shared/listing-form"
+  = render "shared/new-listing-form"
+  = render "shared/new-button"
   = render "shared/new-footer"

--- a/app/views/shared/_new-button.html.haml
+++ b/app/views/shared/_new-button.html.haml
@@ -1,0 +1,21 @@
+.listing__last
+  .listing__last__box
+    .listing__last__box__attention
+      %p
+        =link_to "禁止されている出品", "https://www.mercari.com/jp/help_center/getting_started/prohibited_items/"
+        、
+        =link_to "行為", "https://www.mercari.com/jp/help_center/getting_started/prohibited_conduct/"
+        を必ずご確認ください。
+      %p
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        =link_to "偽ブランドの販売", "https://www.mercari.com/jp/help_center/getting_started/counterfeit_goods/"
+        は犯罪であり処罰される可能性があります。
+      %p
+        また、出品をもちまして
+        =link_to "加盟店規約", "https://www.mercari.com/jp/seller_terms/"
+        に同意したことになります。
+
+      %button.btn-default.btn-red
+        出品する
+      %button.btn-default.btn-gray
+        もどる

--- a/app/views/shared/_new-listing-form.html.haml
+++ b/app/views/shared/_new-listing-form.html.haml
@@ -121,24 +121,3 @@
         .listing__form__price__box__profit
           %p 販売利益
           %p -
-
-    .listing__form__last
-      .listing__form__last__attention
-        %p
-          =link_to "禁止されている出品", "https://www.mercari.com/jp/help_center/getting_started/prohibited_items/"
-          、
-          =link_to "行為", "https://www.mercari.com/jp/help_center/getting_started/prohibited_conduct/"
-          を必ずご確認ください。
-        %p
-          またブランド品でシリアルナンバー等がある場合はご記載ください。
-          =link_to "偽ブランドの販売", "https://www.mercari.com/jp/help_center/getting_started/counterfeit_goods/"
-          は犯罪であり処罰される可能性があります。
-        %p
-          また、出品をもちまして
-          =link_to "加盟店規約", "https://www.mercari.com/jp/seller_terms/"
-          に同意したことになります。
-
-      %button.btn-default.btn-red
-        出品する
-      %button.btn-default.btn-gray
-        もどる


### PR DESCRIPTION
# WHAT
商品出品ページのマークアップの修正（render区切りを変更、それに伴うコード修正）を行った。
具体的な内容としてページ下部のボタン部分のみで別途renderを行った。
# WHY
商品出品編集ページのマークアップ時に、renderを行っているにも関わらず、
edit側も冗長なコードになってしまうため。