### PR TITLE
マイページのクレジットカード登録画面

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import "registration_login";
 @import "./registration_box.scss";
 @import "signup";
+@import "mypage_card";

--- a/app/assets/stylesheets/mypage_card.scss
+++ b/app/assets/stylesheets/mypage_card.scss
@@ -9,7 +9,6 @@
   font-size: 14px;
   .mypage-card__month-form-box{
     @include form-default;
-    // width: 150px;
     .selecters_wrap{
       .select_wrap{
         width: calc(50% - 32px);

--- a/app/assets/stylesheets/mypage_card.scss
+++ b/app/assets/stylesheets/mypage_card.scss
@@ -1,0 +1,23 @@
+.registration__title.mypage__title{
+  box-sizing: border-box;
+  height: 50px;
+  padding: 8px 24px;
+  line-height: 36px;
+}
+.registration__content.mypage__content{
+  padding: 24px 16px 40px;
+  font-size: 14px;
+  .mypage-card__month-form-box{
+    @include form-default;
+    // width: 150px;
+    .selecters_wrap{
+      .select_wrap{
+        width: calc(50% - 32px);
+        display: inline-block;
+      }
+      h2{
+        display: inline-block;
+      }
+    }
+  }
+}

--- a/app/views/mypage_card/new.html.haml
+++ b/app/views/mypage_card/new.html.haml
@@ -1,5 +1,28 @@
-.registration__container
-  .registration__title 支払い方法
-  %form.registration__content
-    .registration__content__box
-      =render 'render/input-form-required',label:'カード番号',example:'半角数字のみ'
+.header
+  =render 'top/header'
+.mypage__container
+  =render 'users/mypage-sidebar'
+  .mypage__main
+    .registration__container
+      .registration__title.mypage__title クレジットカード情報入力
+      %form.registration__content.mypage__content
+        .registration__content__box
+          =render 'render/input-form-required',label:'カード番号',example:'半角数字のみ'
+          = image_tag 'credit_card.jpg'
+          .mypage-card__month-form-box
+            %label 有効期限
+            %span.required 必須
+            .selecters_wrap
+              .select_wrap
+                = date_select(:test, :test, use_month_numbers:true, discard_year:true, discard_day:true)
+                %i.fas.fa-chevron-down
+              %h2 月
+              .select_wrap
+                = date_select(:test1, :test1, discard_month:true,start_year:2019)
+                %i.fas.fa-chevron-down
+              %h2 年 
+          =render 'render/input-form-required',label:'セキュリティコード',example:'カード背面４桁もしくは３桁の番号'
+          =render 'render/help-link',text:'カード裏面の番号とは？',address:root_path
+          =render 'render/input-form-button',name:'追加する'
+.footer
+  = render 'top/footer'


### PR DESCRIPTION
# WHAT
https://gyazo.com/a90db9dbfb53d074cc4b5136e3cd1942
マイページにおけるクレジットカード情報入力画面。
こちらはほとんどユーザー新規登録の際のクレジットカード登録画面（credit_card/new.html.haml）と同じだが、多少の微修正をmypage_card.scssに記述した。