### PR TITLE
Fix image url

### DIFF
--- a/app/assets/javascripts/top/index.js.erb
+++ b/app/assets/javascripts/top/index.js.erb
@@ -1,8 +1,8 @@
 $(document).on('turbolinks:load', function(){
   $('.slider').slick({
     dots: true,
-    prevArrow:'<img src="/assets/prev.png" class="slick-prev">',
-    nextArrow:'<img src="/assets/next.png" class="slick-next">'
+    prevArrow:'<%= image_tag "prev.png",class: "slick-prev"%>',
+    nextArrow:'<%= image_tag "next.png",class:"slick-next"%>'
   });
   $('.slick-dots').find('li').on('mouseover', function() {
     $(this).click();

--- a/app/views/top/_content.html.haml
+++ b/app/views/top/_content.html.haml
@@ -10,7 +10,7 @@
     .contents__items
       .contents__item__box
         .contents__item__box__image
-          = image_tag 'item1', alt: '', height: '213', width: '213', class: ''
+          = image_tag 'item1.jpg', alt: '', height: '213', width: '213', class: ''
         .contents__item__box__item-name
           ecco crepe tray スニーカーブーツ DANISH 23.5
         .contents__item__box__price-favorite
@@ -21,7 +21,7 @@
             %span 6
       .contents__item__box
         .contents__item__box__image
-          = image_tag 'item1', alt: '', height: '213', width: '213', class: ''
+          = image_tag 'item1.jpg', alt: '', height: '213', width: '213', class: ''
         .contents__item__box__item-name
           ecco crepe tray スニーカーブーツ DANISH 23.5
         .contents__item__box__price-favorite
@@ -32,7 +32,7 @@
             %span 6
       .contents__item__box
         .contents__item__box__image
-          = image_tag 'item1', alt: '', height: '213', width: '213', class: ''
+          = image_tag 'item1.jpg', alt: '', height: '213', width: '213', class: ''
         .contents__item__box__item-name
           ecco crepe tray スニーカーブーツ DANISH 23.5
         .contents__item__box__price-favorite
@@ -43,7 +43,7 @@
             %span 6
       .contents__item__box
         .contents__item__box__image
-          = image_tag 'item1', alt: '', height: '213', width: '213', class: ''
+          = image_tag 'item1.jpg', alt: '', height: '213', width: '213', class: ''
         .contents__item__box__item-name
           ecco crepe tray スニーカーブーツ DANISH 23.5555555555555555555555555557777777777777777777777777777777777
         .contents__item__box__price-favorite


### PR DESCRIPTION
# WHAT
本番環境のみ非表示になる画像ファイルを修正した。
http://13.113.2.237/

# 原因
slickのボタン・・・本番環境のjsでは、image_tagを使用できない。
商品画像・・・ファイルの拡張子が指定されていなかった。

# 解決策
slickボタン・・・jsファイルの名前をindex.js.erbへ変更し、image_tagを使用できる状態に修正した。
商品画像・・・拡張子の指定を行った。