### PR TITLE
秘密鍵の読み取り元変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,9 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   protect_from_forgery with: :exception
   require 'payjp'
-  Payjp.api_key=Rails.application.secrets.payjp_secret_key
-  # Payjp.api_key = ENV["SECRET_PAYJP_API_KEY"]
-  # ローカル環境ではsecrets.ymlにapiの秘密鍵を置いているが、本番環境では環境変数/etc/envに設定する。
+  Payjp.api_key=Rails.application.credentials.payjp_secret_key
 
   private
   


### PR DESCRIPTION
# WHY
秘密鍵の読み取り元を設定しないと、本番環境等で全く使えないので。

# WHAT
credentials.ymlから秘密鍵を読み取るように設定した。
デプロイ担当の方に、別途秘密鍵は伝えて、credentails.yml内に設定してもらった。