### PR TITLE
ユーザー登録の画面遷移

### DIFF
--- a/app/assets/stylesheets/common_layout/form.scss
+++ b/app/assets/stylesheets/common_layout/form.scss
@@ -160,6 +160,10 @@
       width: 100%;
       padding-top: 8px;
     }
+    h2{
+      text-align: center;
+      font-size: 22px;
+    }
   }
 }
 

--- a/app/controllers/address_registration_controller.rb
+++ b/app/controllers/address_registration_controller.rb
@@ -5,8 +5,16 @@ class AddressRegistrationController < ApplicationController
     @phone_information = 'completed'
     @address_information_title = "visited"
     @address_information = 'progressed'
+    @address = AddressRegistration.new
   end
 
   def create
+    AddressRegistration.create(address_params)
+    redirect_to controller:'credit_cards',action:"new"
+  end
+
+  private 
+  def address_params
+    params.require(:address_registration).permit(:family_name,:first_name,:family_furigana,:first_furigana,:postal_code,:prefecture_id,:city,:block,:building,:phone_number).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/address_registration_controller.rb
+++ b/app/controllers/address_registration_controller.rb
@@ -1,11 +1,16 @@
 class AddressRegistrationController < ApplicationController
   def new
-    @member_information_title = nil
-    @member_information = "completed"
-    @phone_information = 'completed'
-    @address_information_title = "visited"
-    @address_information = 'progressed'
-    @address = AddressRegistration.new
+    binding.pry
+    if (user_signed_in? && current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.length ==0 && current_user.credit_cards.length ==0)
+      @member_information_title = nil
+      @member_information = "completed"
+      @phone_information = 'completed'
+      @address_information_title = "visited"
+      @address_information = 'progressed'
+      @address = AddressRegistration.new
+    else
+      redirect_to root_path
+    end
   end
 
   def create

--- a/app/controllers/address_registration_controller.rb
+++ b/app/controllers/address_registration_controller.rb
@@ -1,6 +1,5 @@
 class AddressRegistrationController < ApplicationController
   def new
-    binding.pry
     if (user_signed_in? && current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.length ==0 && current_user.credit_cards.length ==0)
       @member_information_title = nil
       @member_information = "completed"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
   protect_from_forgery with: :exception
-  # before_action :registration_check unless :devise_controller? || controller_name == 'phone_number_authorizations' || 'address_registration'|| 'credit_cards' 
+  before_action :registration_check  
   before_action :registration_view_params
   require 'payjp'
   Payjp.api_key=Rails.application.credentials.payjp_secret_key
@@ -23,15 +23,20 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :email, :family_name, :first_name, :family_furigana, :first_furigana, :birth_year, :birth_month, :birth_day])
   end
 
-  def after_sign_up_path_for(resource)
-    redirect_to controller:'/phone_number_authorization', action:'new'
-  end
 
-  # def registration_check
-  #   if current_user != nil && current_user.phone_number_authorization != nil && current_user.address_registration != nil && current_user.credit_card != nil
-  #     redirect_to controller: 'devise', action:'destroy'
-  #   end
-  # end
+  def registration_check
+    # ユーザーがログインしている　かつ　登録の画面でない場合　→　中途半端な登録データを削除しroot_pathに移動
+    if user_signed_in?
+      unless ((controller_name == "phone_number_authorization" && action_name == "new")||(controller_name == "address_registration" && action_name == "new")||(controller_name == "credit_cards" && action_name == "new"))
+        if (current_user.phone_number_authorizations.length == 0 || current_user.address_registrations.length == 0 || current_user.credit_cards.length == 0)
+          unless (current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.lenght != 0 && current_user.credit_cards.length != 0)
+            current_user.destroy
+            redirect_to root_path
+          end
+        end
+      end
+    end
+  end
 
   def registration_view_params
     @member_information_title = "visited"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,8 @@ class ApplicationController < ActionController::Base
   before_action :registration_view_params
   require 'payjp'
   Payjp.api_key=Rails.application.credentials.payjp_secret_key
-
+  # Payjp.api_key=Rails.application.secrets.payjp_secret_key
+  # ローカル環境でのテスト
   private
   
   def basic_auth

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,13 +3,14 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
   protect_from_forgery with: :exception
+  # before_action :registration_check unless :devise_controller? || controller_name == 'phone_number_authorizations' || 'address_registration'|| 'credit_cards' 
   before_action :registration_view_params
   require 'payjp'
   Payjp.api_key=Rails.application.credentials.payjp_secret_key
   # Payjp.api_key=Rails.application.secrets.payjp_secret_key
   # ローカル環境でのテスト
+
   private
-  
   def basic_auth
     if Rails.env.production?
       authenticate_or_request_with_http_basic do |username, password|
@@ -22,10 +23,19 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :email, :family_name, :first_name, :family_furigana, :first_furigana, :birth_year, :birth_month, :birth_day])
   end
 
+  def after_sign_up_path_for(resource)
+    redirect_to controller:'/phone_number_authorization', action:'new'
+  end
+
+  # def registration_check
+  #   if current_user != nil && current_user.phone_number_authorization != nil && current_user.address_registration != nil && current_user.credit_card != nil
+  #     redirect_to controller: 'devise', action:'destroy'
+  #   end
+  # end
+
   def registration_view_params
     @member_information_title = "visited"
     @member_information = "progressed"
   end
-
 end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   def registration_check
     # ユーザーがログインしている　かつ　登録の画面でない場合　→　中途半端な登録データを削除しroot_pathに移動
     if user_signed_in?
-      unless ((controller_name == "phone_number_authorization" && action_name == "new")||(controller_name == "address_registration" && action_name == "new")||(controller_name == "credit_cards" && action_name == "new"))
+      unless ((controller_name == "phone_number_authorization" && action_name == "new"||'create')||(controller_name == "address_registration" && action_name == "new"||'create')||(controller_name == "credit_cards" && action_name == "new"||'create'))
         if (current_user.phone_number_authorizations.length == 0 || current_user.address_registrations.length == 0 || current_user.credit_cards.length == 0)
           unless (current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.lenght != 0 && current_user.credit_cards.length != 0)
             current_user.destroy

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,11 +1,16 @@
 class CreditCardsController < ApplicationController
   def new
-    @member_information_title = nil
-    @member_information = "completed"
-    @phone_information = 'completed'
-    @address_information = 'completed'
-    @credit_information_title = "visited"
-    @credit_information = 'progressed'
+    binding.pry
+    if (user_signed_in? && current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.length !=0 && current_user.credit_cards.length ==0)    
+      @member_information_title = nil
+      @member_information = "completed"
+      @phone_information = 'completed'
+      @address_information = 'completed'
+      @credit_information_title = "visited"
+      @credit_information = 'progressed'
+    else
+      redirect_to root_path
+    end
   end
 
   def create

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,6 +1,5 @@
 class CreditCardsController < ApplicationController
   def new
-    binding.pry
     if (user_signed_in? && current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.length !=0 && current_user.credit_cards.length ==0)    
       @member_information_title = nil
       @member_information = "completed"

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -13,7 +13,7 @@ class CreditCardsController < ApplicationController
     current_user.customer_id = @customer.id
     current_user.save
     CreditCard.create(token_id: @token_id, user_id: current_user.id)
-    redirect_to root_path 
+    redirect_to registration_check_index_path
   end
 
   private

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -9,12 +9,11 @@ class CreditCardsController < ApplicationController
   end
 
   def create
-    # @user = User.find(params[id:current_user.id]) ユーザー登録後に追記する
-    @user = User.find(1)
     create_token(credit_card_params)
-    @user.customer_id = @customer.id
-    @user.save
-    CreditCard.create(token_id: @token_id, user_id: 1)
+    current_user.customer_id = @customer.id
+    current_user.save
+    CreditCard.create(token_id: @token_id, user_id: current_user.id)
+    redirect_to root_path 
   end
 
   private
@@ -35,7 +34,8 @@ class CreditCardsController < ApplicationController
     })
     @token_id = @token.id
     @customer = Payjp::Customer.create()
-    # @customer = Payjp::Customer.retrieve(@user.customer_id)
+    # @customer = Payjp::Customer.retrieve(current_user.customer_id)
+    # 顧客IDを事前に作成して、それを取得する場合はこちらのコードを使用する
     @customer.cards.create(card:@token_id)
   end
 

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -1,0 +1,167 @@
+
+class Devise::RegistrationsController < DeviseController
+  prepend_before_action :require_no_authentication, only: [:new, :create, :cancel]
+  prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy]
+  prepend_before_action :set_minimum_password_length, only: [:new, :edit]
+
+  # GET /resource/sign_up
+  def new
+    build_resource
+    yield resource if block_given?
+    respond_with resource
+  end
+
+  # POST /resource
+  def create
+    build_resource(sign_up_params)
+
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+      if resource.active_for_authentication?
+        set_flash_message! :notice, :signed_up
+        sign_up(resource_name, resource)
+        respond_with resource, location: after_sign_up_path_for(resource)
+      else
+        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+        expire_data_after_sign_in!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  # GET /resource/edit
+  def edit
+    render :edit
+  end
+
+  # PUT /resource
+  # We need to use a copy of the resource because we don't want to change
+  # the current user in place.
+  def update
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    resource_updated = update_resource(resource, account_update_params)
+    yield resource if block_given?
+    if resource_updated
+      set_flash_message_for_update(resource, prev_unconfirmed_email)
+      bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
+
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  # DELETE /resource
+  def destroy
+    resource.destroy
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message! :notice, :destroyed
+    yield resource if block_given?
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+  end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  def cancel
+    expire_data_after_sign_in!
+    redirect_to new_registration_path(resource_name)
+  end
+
+  protected
+
+  def update_needs_confirmation?(resource, previous)
+    resource.respond_to?(:pending_reconfirmation?) &&
+      resource.pending_reconfirmation? &&
+      previous != resource.unconfirmed_email
+  end
+
+  # By default we want to require a password checks on update.
+  # You can overwrite this method in your own RegistrationsController.
+  def update_resource(resource, params)
+    resource.update_with_password(params)
+  end
+
+  # Build a devise resource passing in the session. Useful to move
+  # temporary session data to the newly created user.
+  def build_resource(hash = {})
+    self.resource = resource_class.new_with_session(hash, session)
+  end
+
+  # Signs in a user on sign up. You can overwrite this method in your own
+  # RegistrationsController.
+  def sign_up(resource_name, resource)
+    sign_in(resource_name, resource)
+  end
+
+  # The path used after sign up. You need to overwrite this method
+  # in your own RegistrationsController.
+  def after_sign_up_path_for(resource)
+    new_phone_number_authorization_path
+  end
+
+  # The path used after sign up for inactive accounts. You need to overwrite
+  # this method in your own RegistrationsController.
+  def after_inactive_sign_up_path_for(resource)
+    scope = Devise::Mapping.find_scope!(resource)
+    router_name = Devise.mappings[scope].router_name
+    context = router_name ? send(router_name) : self
+    context.respond_to?(:root_path) ? context.root_path : "/"
+  end
+
+  # The default url to be used after updating a resource. You need to overwrite
+  # this method in your own RegistrationsController.
+  def after_update_path_for(resource)
+    sign_in_after_change_password? ? signed_in_root_path(resource) : new_session_path(resource_name)
+  end
+
+  # Authenticates the current scope and gets the current resource from the session.
+  def authenticate_scope!
+    send(:"authenticate_#{resource_name}!", force: true)
+    self.resource = send(:"current_#{resource_name}")
+  end
+
+  def sign_up_params
+    devise_parameter_sanitizer.sanitize(:sign_up)
+  end
+
+  def account_update_params
+    devise_parameter_sanitizer.sanitize(:account_update)
+  end
+
+  def translation_scope
+    'devise.registrations'
+  end
+
+  private
+
+  def set_flash_message_for_update(resource, prev_unconfirmed_email)
+    return unless is_flashing_format?
+
+    flash_key = if update_needs_confirmation?(resource, prev_unconfirmed_email)
+                  :update_needs_confirmation
+                elsif sign_in_after_change_password?
+                  :updated
+                else
+                  :updated_but_not_signed_in
+                end
+    set_flash_message :notice, flash_key
+  end
+
+  def sign_in_after_change_password?
+    return true if account_update_params[:password].blank?
+
+    Devise.sign_in_after_change_password
+  end
+end

--- a/app/controllers/phone_number_authorization_controller.rb
+++ b/app/controllers/phone_number_authorization_controller.rb
@@ -1,6 +1,5 @@
 class PhoneNumberAuthorizationController < ApplicationController
   def new
-    binding.pry
     if (user_signed_in? && current_user.phone_number_authorizations.length == 0 && current_user.address_registrations.length ==0 && current_user.credit_cards.length ==0)
       @member_information_title = nil
       @member_information = "completed"
@@ -13,7 +12,6 @@ class PhoneNumberAuthorizationController < ApplicationController
   end
 
   def create
-    binding.pry
     PhoneNumberAuthorization.create(phone_params)
     redirect_to controller:"address_registration", action:'new'
   end

--- a/app/controllers/phone_number_authorization_controller.rb
+++ b/app/controllers/phone_number_authorization_controller.rb
@@ -1,13 +1,19 @@
 class PhoneNumberAuthorizationController < ApplicationController
   def new
-    @member_information_title = nil
-    @member_information = "completed"
-    @phone_information_title = "visited"
-    @phone_information = 'progressed'
-    @phone = PhoneNumberAuthorization.new
+    binding.pry
+    if (user_signed_in? && current_user.phone_number_authorizations.length == 0 && current_user.address_registrations.length ==0 && current_user.credit_cards.length ==0)
+      @member_information_title = nil
+      @member_information = "completed"
+      @phone_information_title = "visited"
+      @phone_information = 'progressed'
+      @phone = PhoneNumberAuthorization.new
+    else
+      redirect_to root_path
+    end
   end
 
   def create
+    binding.pry
     PhoneNumberAuthorization.create(phone_params)
     redirect_to controller:"address_registration", action:'new'
   end

--- a/app/controllers/phone_number_authorization_controller.rb
+++ b/app/controllers/phone_number_authorization_controller.rb
@@ -4,8 +4,16 @@ class PhoneNumberAuthorizationController < ApplicationController
     @member_information = "completed"
     @phone_information_title = "visited"
     @phone_information = 'progressed'
+    @phone = PhoneNumberAuthorization.new
   end
 
   def create
+    PhoneNumberAuthorization.create(phone_params)
+    redirect_to controller:"address_registration", action:'new'
+  end
+
+  private
+  def phone_params
+    params.require(:phone_number_authorization).permit(:telephone).merge(user_id:current_user.id)
   end
 end

--- a/app/controllers/registration_check_controller.rb
+++ b/app/controllers/registration_check_controller.rb
@@ -1,0 +1,4 @@
+class RegistrationCheckController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/registration_check_controller.rb
+++ b/app/controllers/registration_check_controller.rb
@@ -1,11 +1,15 @@
 class RegistrationCheckController < ApplicationController
   def index
-    @member_information_title = nil
-    @member_information = "completed"
-    @phone_information = 'completed'
-    @address_information = 'completed'
-    @credit_information = 'completed'
-    @registration_check_title = 'visited'
-    @registration_check = 'progressed'
+    if (user_signed_in? && current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.length !=0 && current_user.credit_cards.length !=0)        
+      @member_information_title = nil
+      @member_information = "completed"
+      @phone_information = 'completed'
+      @address_information = 'completed'
+      @credit_information = 'completed'
+      @registration_check_title = 'visited'
+      @registration_check = 'progressed'
+    else
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/registration_check_controller.rb
+++ b/app/controllers/registration_check_controller.rb
@@ -1,4 +1,11 @@
 class RegistrationCheckController < ApplicationController
   def index
+    @member_information_title = nil
+    @member_information = "completed"
+    @phone_information = 'completed'
+    @address_information = 'completed'
+    @credit_information = 'completed'
+    @registration_check_title = 'visited'
+    @registration_check = 'progressed'
   end
 end

--- a/app/models/address_registration.rb
+++ b/app/models/address_registration.rb
@@ -1,0 +1,5 @@
+class AddressRegistration < ApplicationRecord
+  belongs_to :user
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+end

--- a/app/models/phone_number_authorization.rb
+++ b/app/models/phone_number_authorization.rb
@@ -1,0 +1,3 @@
+class PhoneNumberAuthorization < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,8 @@ class User < ApplicationRecord
   has_many :purchases
   has_many :user_identifications
   has_many :phone_number_authorizations
- 
+  has_many :address_registrations
+
   validates :nickname, :family_name, :first_name, :family_furigana, :first_furigana, :birth_year, :birth_month, :birth_day,presence: true
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :credit_cards
   has_many :purchases
   has_many :user_identifications
+  has_many :phone_number_authorizations
  
   validates :nickname, :family_name, :first_name, :family_furigana, :first_furigana, :birth_year, :birth_month, :birth_day,presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,12 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :credit_cards
-  has_many :purchases
-  has_many :user_identifications
-  has_many :phone_number_authorizations
-  has_many :address_registrations
+  has_many :credit_cards,dependent: :destroy
+  has_many :purchases,dependent: :destroy
+  has_many :user_identifications,dependent: :destroy
+  has_many :phone_number_authorizations,dependent: :destroy
+  has_many :address_registrations,dependent: :destroy
 
   validates :nickname, :family_name, :first_name, :family_furigana, :first_furigana, :birth_year, :birth_month, :birth_day,presence: true
-
+  
 end

--- a/app/views/address_registration/new.html.haml
+++ b/app/views/address_registration/new.html.haml
@@ -1,7 +1,7 @@
 = render 'signup/registration-header'
 .registration__container
   .registration__title 住所入力
-  = form_with url:address_registration_index_path,class:'registration__content' do |f|
+  = form_with model:@address, url:address_registration_index_path,class:'registration__content' do |f|
     .registration__content__box
       .input-form-box.first-form
         %label お名前

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,7 +1,7 @@
 = render 'signup/registration-header'
 .registration__container
   .registration__title 支払い方法
-  = form_with  url:user_credit_cards_path,class:'registration__content',id:'new_credit_card' do |f|
+  = form_with  url:credit_cards_path,class:'registration__content',id:'new_credit_card' do |f|
     .registration__content__box
       = render 'render/input-form-required',label:'カード番号',example:'半角数字のみ',form: f, name: :number
       = image_tag 'credit_card.jpg'

--- a/app/views/phone_number_authorization/new.html.haml
+++ b/app/views/phone_number_authorization/new.html.haml
@@ -1,7 +1,7 @@
 = render 'signup/registration-header'
 .registration__container
   .registration__title 電話番号の確認
-  = form_with url:phone_number_authorization_index_path,class:'registration__content' do |f|
+  = form_with model:@phone,url:phone_number_authorization_index_path,class:'registration__content' do |f|
     .registration__content__box
       .input-form-box.first-form
         %label 携帯電話の番号

--- a/app/views/registration_check/index.html.haml
+++ b/app/views/registration_check/index.html.haml
@@ -1,0 +1,12 @@
+= render 'signup/registration-header'
+.registration__container
+  .registration__title 会員登録完了
+  .registration__content
+    .registration__content__box
+      %h2 ありがとうございます。
+      %h2 会員登録が完了しました。
+      .input-form-box
+        .button-wrap
+          = link_to 'メルカリを始める', root_path, class:'btn-red'
+%footer.registration_login-footer.test
+  =render 'signup/registration_login_footer'

--- a/app/views/signup/_registration-header.html.haml
+++ b/app/views/signup/_registration-header.html.haml
@@ -14,6 +14,6 @@
       %li{class:@credit_information_title}
         支払い方法
         .progress-status{class:@credit_information}
-      %li
+      %li{class:@registration_check_title}
         完了
-        .progress-status
+        .progress-status{class:@registration_check}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
   resources :products, only:[:show, :new, :edit, :create] do
     resources :purchases, only:[:new,:create]
   end
+  resources :registration_check, only: [:index]
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,13 +6,13 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: [:index,:edit] do
-    resources :credit_cards, only:[:new,:create]
     resources :mypage_card, only:[:index,:new]
   end
   resources :user_identifications, only: [:new,:create]
   resources :signup, only: [:index]
   resources :phone_number_authorization, only:[:new,:create]
   resources :address_registration, only:[:new,:create]
+  resources :credit_cards, only:[:new,:create]
   resources :mypage_card, only:[:index,:new]
   resources :user_profile, only:[:new,:edit]
   resources :products, only:[:show, :new, :edit, :create] do

--- a/db/migrate/20190812092026_phone_number_authorization.rb
+++ b/db/migrate/20190812092026_phone_number_authorization.rb
@@ -1,0 +1,10 @@
+class PhoneNumberAuthorization < ActiveRecord::Migration[5.2]
+  def change
+    create_table :phone_number_authorizations do |t|
+      
+      t.integer :telephone, unique:true, null:false
+      t.references :user, foreign_key: :true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190813055807_address_registration.rb
+++ b/db/migrate/20190813055807_address_registration.rb
@@ -1,0 +1,18 @@
+class AddressRegistration < ActiveRecord::Migration[5.2]
+  def change
+    create_table :address_registrations do |t|
+      t.string :family_name, null:false
+      t.string :first_name, null:false
+      t.string :family_furigana, null:false
+      t.string :first_furigana, null:false
+      t.integer :postal_code, null:false
+      t.integer :prefecture_id, null:false
+      t.string :city, null:false
+      t.string :block, null:false
+      t.string :building
+      t.integer :phone_number, null:false
+      t.references :user, foreign_key: :true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_08_10_082214) do
+ActiveRecord::Schema.define(version: 2019_08_12_092026) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,12 +32,21 @@ ActiveRecord::Schema.define(version: 2019_08_10_082214) do
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
+
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "token_id", null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_credit_cards_on_user_id"
+  end
+
+  create_table "phone_number_authorizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "telephone", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_phone_number_authorizations_on_user_id"
   end
 
   create_table "products", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -53,7 +61,7 @@ ActiveRecord::Schema.define(version: 2019_08_10_082214) do
     t.integer "category_id"
     t.integer "user_id"
     t.integer "prefecture_id", null: false
-    t.integer "purchase_status_id"
+    t.integer "purchase_status_id", null: false
   end
 
   create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -102,9 +110,7 @@ ActiveRecord::Schema.define(version: 2019_08_10_082214) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "credit_cards", "users"
-  add_foreign_key "purchases", "products"
-  add_foreign_key "purchases", "users"
-  add_foreign_key "credit_cards", "users"
+  add_foreign_key "phone_number_authorizations", "users"
   add_foreign_key "purchases", "products"
   add_foreign_key "purchases", "users"
   add_foreign_key "user_identifications", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_12_092026) do
+ActiveRecord::Schema.define(version: 2019_08_13_055807) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,23 @@ ActiveRecord::Schema.define(version: 2019_08_12_092026) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "address_registrations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_furigana", null: false
+    t.string "first_furigana", null: false
+    t.integer "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "block", null: false
+    t.string "building"
+    t.integer "phone_number", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_address_registrations_on_user_id"
   end
 
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -109,6 +126,7 @@ ActiveRecord::Schema.define(version: 2019_08_12_092026) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "address_registrations", "users"
   add_foreign_key "credit_cards", "users"
   add_foreign_key "phone_number_authorizations", "users"
   add_foreign_key "purchases", "products"


### PR DESCRIPTION
# WHY
複数のビューで入力された情報を、一つのユーザーのデータとして保存したい。

# WHAT
- 今のとこ、情報の保存とページの遷移はできた。
- 一連のユーザー情報登録画面以外において、住所電話番号等の情報が一部欠けている場合は、ユーザーごと消去することで一貫性を保とうとしている。
application_controller.rbのregistration_checkが該当箇所。
- 電話番号登録の時はユーザーデータのみ、住所登録の時はユーザーデータと電話番号のみ、クレジットカードの時はユーザーと電話と住所、最後の終了画面はそれら全てが埋まっていないと、root_pathに戻されて、1つ上で記述したregistration_checkによりユーザーデータが破棄される、という形にしてある。


# PROBLEM
- 一部しか情報が保存されていない場合に、そのユーザーデータを破棄する方法をapplication_controller.rbに記述したい。→ appliation.rb内のregistration_checkで解決。
- ページの遷移の順番がおかしい場合にもエラーを返したい。これに関しては、ユーザーに付随する電話番号、住所、クレジットカード情報がおかしな埋まり方をしている場合にエラーを返す、というのでできそう？→　各controllerのnewアクションに条件文を記述。