### PR TITLE
[fix]ユーザー登録の画面遷移

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,6 @@ class ApplicationController < ActionController::Base
       binding.pry
       unless (registration_view_check)
         if (registration_data_check)
-          binding.pry
             current_user.destroy
             redirect_to root_path
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,16 +23,26 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :email, :family_name, :first_name, :family_furigana, :first_furigana, :birth_year, :birth_month, :birth_day])
   end
 
+  # ユーザー登録画面であればtrue, そうでなければfalse
+  def registration_view_check
+    (controller_name == "phone_number_authorization" && action_name == ("new"||'create'))||(controller_name == "address_registration" && action_name == ("new"||'create'))||(controller_name == "credit_cards" && action_name == ("new"||'create'))
+  end
+
+  # ユーザーのデータに空白があるかどうかをチェック
+  def registration_data_check
+    current_user.phone_number_authorizations.length == 0 || current_user.address_registrations.length == 0 || current_user.credit_cards.length == 0
+  end
+
 
   def registration_check
-    # ユーザーがログインしている　かつ　登録の画面でない場合　→　中途半端な登録データを削除しroot_pathに移動
+    # ユーザーがログインしている　かつ　登録の途中でない場合　かつ　データに欠損がある→　中途半端な登録データを削除しroot_pathに移動
     if user_signed_in?
-      unless ((controller_name == "phone_number_authorization" && action_name == "new"||'create')||(controller_name == "address_registration" && action_name == "new"||'create')||(controller_name == "credit_cards" && action_name == "new"||'create'))
-        if (current_user.phone_number_authorizations.length == 0 || current_user.address_registrations.length == 0 || current_user.credit_cards.length == 0)
-          unless (current_user.phone_number_authorizations.length != 0 && current_user.address_registrations.lenght != 0 && current_user.credit_cards.length != 0)
+      binding.pry
+      unless (registration_view_check)
+        if (registration_data_check)
+          binding.pry
             current_user.destroy
             redirect_to root_path
-          end
         end
       end
     end


### PR DESCRIPTION
# WHY
複数のビューで入力された情報を、一つのユーザーのデータとして保存したい。

# WHAT
- 今のとこ、情報の保存とページの遷移はできた。
- 一連のユーザー情報登録画面以外において、住所電話番号等の情報が一部欠けている場合は、ユーザーごと消去することで一貫性を保とうとしている。
application_controller.rbのregistration_checkが該当箇所。
- 電話番号登録の時はユーザーデータのみ、住所登録の時はユーザーデータと電話番号のみ、クレジットカードの時はユーザーと電話と住所、最後の終了画面はそれら全てが埋まっていないと、root_pathに戻されて、1つ上で記述したregistration_checkによりユーザーデータが破棄される、という形にしてある。


# PROBLEM
- 一部しか情報が保存されていない場合に、そのユーザーデータを破棄する方法をapplication_controller.rbに記述したい。→ appliation.rb内のregistration_checkで解決。
- ページの遷移の順番がおかしい場合にもエラーを返したい。これに関しては、ユーザーに付随する電話番号、住所、クレジットカード情報がおかしな埋まり方をしている場合にエラーを返す、というのでできそう？→　各controllerのnewアクションに条件文を記述。