### PR TITLE
SNS新規登録　実装

### DIFF
--- a/app/assets/stylesheets/top/_content.scss
+++ b/app/assets/stylesheets/top/_content.scss
@@ -132,7 +132,7 @@
         opacity: 1;
     }
   }
-}
+  
 .camera{
   height: 160px;
   width: 160px;

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,5 +1,6 @@
 class SignupController < ApplicationController
-  
+  before_action :authenticate_user!, except: :index
+
   def index
   end
 

--- a/app/views/signup/index.html.haml
+++ b/app/views/signup/index.html.haml
@@ -6,14 +6,16 @@
       %h2.signup-box-head 新規会員登録
       .signup
         .signup__email
-          = link_to "#", class: "btn-default btn-mail" do
+          = link_to new_user_registration_path, class: "btn-default btn-mail" do
             メールアドレスで登録する
             %i.far.fa-envelope
         .signup__social
-          %button#facebook-login.btn-default.btn-sns-facebook
-            Facebookで登録する
-            %i.fab.fa-facebook-square
-          %button#google-login.btn-default.btn-sns-google Googleで登録する
+          = link_to user_facebook_omniauth_authorize_path, method: :post do
+            %button#facebook-login.btn-default.btn-sns-facebook
+              Facebookで登録する
+              %i.fab.fa-facebook-square
+          = link_to user_google_oauth2_omniauth_authorize_path, method: :post do
+            %button#google-login.btn-default.btn-sns-google Googleで登録する
 
   %footer.registration_login-footer.test
     = render "registration_login_footer"


### PR DESCRIPTION
# WHAT
SNSでの新規登録のために、以下の点を修正した。
・before_action :authenticate_user!, except: :index
　未ログイン時に新規登録画面に行くとログイン画面に戻るのを防ぐ
・ログイン画面と同じように、SNSボタンをlink_toで囲む
・メールアドレスボタンのlink_toを修正
# WHY
・SNSでの新規登録のため
