### PR TITLE
購入のパス整備

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -16,9 +16,13 @@ class ProductsController < TopController
   end
 
   def show
-    @comments = @product.comments.includes(:user)
-    @user_products = Product.where(user_id:@product.user_id).where.not(id:@product.id).limit(6).order('id DESC')
-    @related_products = Product.where(category_id:@product.category_id).where.not(id:@product.id).limit(6).order('id DESC')
+    if current_user.id != @product.user.id
+      @comments = @product.comments.includes(:user)
+      @user_products = Product.where(user_id:@product.user_id).where.not(id:@product.id).limit(6).order('id DESC')
+      @related_products = Product.where(category_id:@product.category_id).where.not(id:@product.id).limit(6).order('id DESC')
+    else
+      redirect_to status_product_path(@product.id)
+    end
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -16,7 +16,7 @@ class ProductsController < TopController
   end
 
   def show
-    if current_user.id != @product.user.id
+    if current_user != @product.user
       @comments = @product.comments.includes(:user)
       @user_products = Product.where(user_id:@product.user_id).where.not(id:@product.id).limit(6).order('id DESC')
       @related_products = Product.where(category_id:@product.category_id).where.not(id:@product.id).limit(6).order('id DESC')
@@ -49,7 +49,7 @@ class ProductsController < TopController
 
 
   def destroy
-      if @product.user_id == current_user.id
+      if @product.user == current_user
         @product.images.purge
         @product.delete
         redirect_to users_path
@@ -57,7 +57,7 @@ class ProductsController < TopController
   end
 
   def update
-    if @product.user_id == current_user.id
+    if @product.user == current_user
       @product.update(listing_params)
     end
     redirect_to root_path

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,13 +1,17 @@
 class PurchasesController < ApplicationController
   def new
     @product = Product.find(params[:product_id])
-    @customer = Payjp::Customer.retrieve(current_user.customer_id)
-    card = @customer.cards.data[0]
-    # カードが複数ある場合にどのカードを選ぶのかは問題だが、とりあえず一番目
-    @brand = card.brand
-    @last4 = card.last4
-    @month = card.exp_month
-    @year = card.exp_year
+    if current_user.id != @product.user.id
+      @customer = Payjp::Customer.retrieve(current_user.customer_id)
+      card = @customer.cards.data[0]
+      # カードが複数ある場合にどのカードを選ぶのかは問題だが、とりあえず一番目
+      @brand = card.brand
+      @last4 = card.last4
+      @month = card.exp_month
+      @year = card.exp_year
+    else
+      redirect_to root_path
+    end
   end
 
   def create

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,7 +1,7 @@
 class PurchasesController < ApplicationController
+  before_action :target_product 
   def new
-    @product = Product.find(params[:product_id])
-    if current_user.id != @product.user.id
+    if current_user != @product.user
       @customer = Payjp::Customer.retrieve(current_user.customer_id)
       card = @customer.cards.data[0]
       # カードが複数ある場合にどのカードを選ぶのかは問題だが、とりあえず一番目
@@ -34,5 +34,9 @@ class PurchasesController < ApplicationController
 
   def purchase_params
     params.permit(:product_id).merge(current_user.id,current_user.customer_id)
+  end
+
+  def target_product
+    @product = Product.find(params[:product_id])
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -16,7 +16,7 @@ class PurchasesController < ApplicationController
 
   def create
     @product = Product.find(params[:product_id])
-    if current_user != @product.user
+    if current_user != @product.user && @product.purchase_status_id == 1
       charge = Payjp::Charge.create(
         amount: @product.price,
         customer: current_user.customer_id,

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -12,14 +12,18 @@ class PurchasesController < ApplicationController
 
   def create
     @product = Product.find(params[:product_id])
-    charge = Payjp::Charge.create(
-      amount: @product.price,
-      customer: current_user.customer_id,
-      currency: 'jpy',
-    )
-    Purchase.create(purchase_id:charge.id,product_id: params[:product_id],user_id:current_user.id)
-    @product.update(purchase_status_id: 2)
-    redirect_to root_path
+    if current_user != @product.user
+      charge = Payjp::Charge.create(
+        amount: @product.price,
+        customer: current_user.customer_id,
+        currency: 'jpy',
+      )
+      Purchase.create(purchase_id:charge.id,product_id: params[:product_id],user_id:current_user.id)
+      @product.update(purchase_status_id: 2)
+      redirect_to root_path
+    else
+      redirect_to  new_product_purchase_path(@product.id)
+    end
   end
 
   private

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -79,7 +79,7 @@
       .item-detail__shipping_cost
         送料込み
     .item-detail__purchase-button
-      = link_to '購入画面に進む', "/"
+      = link_to '購入画面に進む',  new_product_purchase_path(@product.id)
     .item-detail__comment
       = @product.description
     .item-detail__like-bad-other

--- a/app/views/top/_header.html.haml
+++ b/app/views/top/_header.html.haml
@@ -46,38 +46,39 @@
             %span やることリスト
           %ul.header-bottom__user-menu__todolist__content
             %li.header-bottom__user-menu__todolist__content__view  現在やることはありません
-        %li.header-bottom__user-menu__mypage
-          =link_to users_path, class:'header-bottom__user-menu__mypage__icon' do
-            =image_tag "member_photo_noimage_thumb.png"
-            %span マイページ
-          .header-bottom__user-menu__mypage__box
-            .header-bottom__user-menu__mypage__box__status
-              %figure.header-bottom__user-menu__mypage__box__status__user-icon
-                %div
-                  = image_tag "member_photo_noimage_thumb.png"
-                %figucaption ユーザー名
-              %ul.header-bottom__user-menu__mypage__box__status__reviewlist
-                %li.user_status
-                  = link_to "評価:0", "/"
-                %li.user_status
-                  = link_to "出品数:0", "/" 
-              %ul.header-bottom__user-menu__mypage__box__status__salespoint
-                %li.user_status
-                  %a
-                    .l-left 売上金
-                    .l-right 
-                      = "0"
-                      %i.fa.fa-arrow-right
-                %li.user_status
-                  %a
-                    .l-left ポイント
-                    .l-right 
-                      = "0"
-                      %i.fa.fa-arrow-right
-            %ul.header-bottom__user-menu__mypage__box__nav
-              = render partial:'top/header_usermenu_card', locals:{card:"いいね一覧"}
-              = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-出品中"}
-              = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-取引中"}
-              = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-売却済"}
-              = render partial:'top/header_usermenu_card', locals:{card:"購入した商品-取引中"}
-              = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-過去の取引"}
+        - if user_signed_in?
+          %li.header-bottom__user-menu__mypage
+            =link_to users_path, class:'header-bottom__user-menu__mypage__icon' do
+              =image_tag "member_photo_noimage_thumb.png"
+              %span マイページ
+            .header-bottom__user-menu__mypage__box
+              .header-bottom__user-menu__mypage__box__status
+                %figure.header-bottom__user-menu__mypage__box__status__user-icon
+                  %div
+                    = image_tag "member_photo_noimage_thumb.png"
+                  %figucaption #{current_user.nickname}
+                %ul.header-bottom__user-menu__mypage__box__status__reviewlist
+                  %li.user_status
+                    = link_to "評価:0", "/"
+                  %li.user_status
+                    = link_to "出品数:0", "/" 
+                %ul.header-bottom__user-menu__mypage__box__status__salespoint
+                  %li.user_status
+                    %a
+                      .l-left 売上金
+                      .l-right 
+                        = "0"
+                        %i.fa.fa-arrow-right
+                  %li.user_status
+                    %a
+                      .l-left ポイント
+                      .l-right 
+                        = "0"
+                        %i.fa.fa-arrow-right
+              %ul.header-bottom__user-menu__mypage__box__nav
+                = render partial:'top/header_usermenu_card', locals:{card:"いいね一覧"}
+                = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-出品中"}
+                = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-取引中"}
+                = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-売却済"}
+                = render partial:'top/header_usermenu_card', locals:{card:"購入した商品-取引中"}
+                = render partial:'top/header_usermenu_card', locals:{card:"出品した商品-過去の取引"}

--- a/app/views/users/_mypage-main.html.haml
+++ b/app/views/users/_mypage-main.html.haml
@@ -3,7 +3,7 @@
     = link_to("/users") do
       =image_tag "member_photo_noimage_thumb.png"
       %h2.mypage__username
-        = "username"
+        = current_user.nickname
       %ul.usericon__evaluation
         %li.usericon__evaluation__value
           %h3 評価 :0


### PR DESCRIPTION
# WHY
一連の商品購入の流れを再現できるようにしたい。また出品者が購入に関連する画面に遷移しないように、条件分岐をコントローラーでつけた。

# WHAT
- ユーザーの名前が表示されるように微修正。
- 購入画面に進む時に、purchase newに進むように設定した。
- purchase_controllerのnewアクション（商品購入画面）に飛んだ時に、もし出品者とログインしているユーザーが一致しているなら、root_pathに戻すようにした。
- purchase_controllerのcreateアクションで決済がなされるが、それの前にユーザーが出品者と一致しているのか確認するようにした。もし出品者と一緒なら、ひとまず同じ画面に戻している。
- products_controllerのshowアクションに飛んだ時に、もしログインユーザーと出品者が一致している時には、商品の編集、停止画面に進むように設定した。

# ISSUE
- フラッシュメッセージを表示しないと、購入できなかったのかどうかわからない。。