### PR TITLE
他人の商品の編集・削除を出来なくする

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -37,14 +37,17 @@ class ProductsController < TopController
   end
 
   def edit
+    current_user != @product.user
   end
 
 
   def destroy
-      if @product.user_id == current_user.id
+      if current_user == @product.user
         @product.images.purge
         @product.delete
         redirect_to users_path
+      else
+        redirect_to root_path
       end
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -37,7 +37,6 @@ class ProductsController < TopController
   end
 
   def edit
-    current_user != @product.user
   end
 
 
@@ -54,6 +53,8 @@ class ProductsController < TopController
   def update
     if @product.user_id == current_user.id
       @product.update(listing_params)
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/views/products/status.html.haml
+++ b/app/views/products/status.html.haml
@@ -80,15 +80,16 @@
         送料込み
     .item-detail__comment
       = @product.description
-    .item-detail__status
-      .item-detail__status__edit-button.red
-        = link_to '商品の編集', edit_product_path
-      .item-detail__status__other
-        or
-      .item-detail__status__edit-button.gray
-        = link_to '出品を一旦停止する', "/"
-      .item-detail__status__edit-button.gray
-        = link_to 'この商品を削除する', product_path, method: :delete
+    - if user_signed_in? && @product.user_id == current_user.id
+      .item-detail__status
+        .item-detail__status__edit-button.red
+          = link_to '商品の編集', edit_product_path
+        .item-detail__status__other
+          or
+        .item-detail__status__edit-button.gray
+          = link_to '出品を一旦停止する', "/"
+        .item-detail__status__edit-button.gray
+          = link_to 'この商品を削除する', product_path, method: :delete
     .item-detail__comment
       .item-detail__comment__box
         - @comments.each do |comment|


### PR DESCRIPTION
# WHAT
商品の削除・編集時に、出品者とログインユーザーが一致しなければ、
トップページへ遷移させる
また、商品編集・削除ページへのリンクが、ログインユーザーが出品ユーザー出ない時に、
リンクを表示しないようにviewを編集した

# WHY
出品者以外が、商品の削除・編集するのを防ぐため