### PR TITLE
出品者以外が、商品の編集や削除ページへ遷移できなくする

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < TopController
   skip_before_action :authenticate_user!, only: [:search]
   before_action :set_product, only: [:show,:edit,:update,:status,:destroy] # 対象となる商品を設定
+  before_action :correct_user?, only:[:status, :edit, :destroy, :update]
 
   def search
     @q = Product.search(search_params)
@@ -37,39 +38,26 @@ class ProductsController < TopController
 
   def buy
   end
-  
+
   def status
     @comments = @product.comments.includes(:user)
   end
 
   def edit
-    if @product.user == current_user
-      @product = Product.find(params[:id])
-      @bigcategory_id = @product.category.parent.grandparent.id
-      @middlecategory_id = @product.category.parent.id
-    else
-      redirect_to root_path
-    end
+    @product = Product.find(params[:id])
+    @bigcategory_id = @product.category.parent.grandparent.id
+    @middlecategory_id = @product.category.parent.id
   end
 
-
   def destroy
-    if @product.user == current_user
-      @product.images.purge
-      @product.delete
-      redirect_to users_path
-    else
-      redirect_to root_path
-    end
+    @product.images.purge
+    @product.delete
+    redirect_to users_path
   end
 
   def update
-    if @product.user == current_user
-      @product.update(listing_params)
-    else
-      redirect_to root_path
-    end
-    redirect_to root_path
+    @product.update(listing_params)
+    redirect_to users_path
   end
 
   def set_product
@@ -80,8 +68,14 @@ class ProductsController < TopController
   def listing_params
     params.require(:product).permit(:name, :description,:category_grandparent_id, :category_parent_id,:category_id, :size_id, :status_id, :shipping_fee_id, :shipping_method_id, :prefecture_id, :shipping_date_id, :price, images: []).merge(user_id: current_user.id, purchase_status_id:1)
   end
-  
+
   def search_params
     params.require(:q).permit(:search_order,:name_cont,:brand_cont,:size_id_eq,:status_id_eq,:shipping_fee_id_eq,:purchase_status_id_eq,:category_grandparent_id_eq,:category_parent_id_eq,:category_id_eq,:price_lteq,:price_gteq)
+  end
+
+  def correct_user?
+    if @product.user != current_user
+      redirect_to root_path
+    end
   end
 end


### PR DESCRIPTION
# WHAT
controllerにbefore_actionを追加
edit, update, destroy,statusアクションの前にログインユーザーが対象商品の出品者かどうかの確認を行う

# WHY
出品者以外のユーザーが、出品中商品の編集や削除を出来ないようにするため