### PR TITLE
クレジットカード登録をjsに変更

### DIFF
--- a/app/assets/javascripts/purchase.js
+++ b/app/assets/javascripts/purchase.js
@@ -22,7 +22,7 @@ $(document).on('turbolinks:load', function() {
         dataType: 'json',
       })
       .done(function(){
-        window.location = "/";
+        window.location = "/registration_check";
       })
       .fail(function(){
         return false;

--- a/app/assets/javascripts/purchase.js
+++ b/app/assets/javascripts/purchase.js
@@ -1,0 +1,32 @@
+$(document).on('turbolinks:load', function() {
+  $(".registration__content mypage__content").submit(function(e){
+    e.preventDefault();
+    Payjp.setPublicKey('pk_test_d7948e7275630f3552910c45');
+    var card = {
+      number: document.querySelector('input[name="number"]').value,
+      cvc: document.querySelector('input[name="cvc"]').value,
+      exp_month: document.querySelector('select[name="select[exp_month(2i)]"]').value,
+      exp_year: document.querySelector('select[name="select[exp_year(1i)]"]').value
+    };
+    Payjp.createToken(card, function(status, response) {
+      if (status === 200) {
+        var token = response.id
+        $('input').val("");
+      } else {
+        alert("error");
+      };
+      $.ajax({
+        type: "POST",
+        url:  "/credit_cards",
+        data: {token: token},
+        dataType: 'json',
+      })
+      .done(function(){
+        window.location = "/";
+      })
+      .fail(function(){
+        return false;
+      })
+    });
+  })
+});

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -13,35 +13,17 @@ class CreditCardsController < ApplicationController
   end
 
   def create
-    create_token(credit_card_params)
+    @customer = Payjp::Customer.create()
+    # @customer = Payjp::Customer.retrieve(current_user.customer_id)
+    # 顧客IDを事前に作成して、それを取得する場合はこちらのコードを使用する
     current_user.customer_id = @customer.id
     current_user.save
-    CreditCard.create(token_id: @token_id, user_id: current_user.id)
-    redirect_to registration_check_index_path
+    CreditCard.create(token_id: params[:token], user_id: current_user.id)
   end
 
   private
   def credit_card_params
     params.permit(:number,:cvc,:user_id).merge(params.require(:select).permit(:exp_month,:exp_year))
   end
-
-  def create_token(credit_card_params)
-    @token = Payjp::Token.create({
-      :card => {
-      :number => credit_card_params[:number],
-      :cvc => credit_card_params[:cvc],
-      :exp_month => credit_card_params["exp_month(2i)"],
-      :exp_year => credit_card_params["exp_year(1i)"]
-    }},
-    {
-      'X-Payjp-Direct-Token-Generate': 'true'
-    })
-    @token_id = @token.id
-    @customer = Payjp::Customer.create()
-    # @customer = Payjp::Customer.retrieve(current_user.customer_id)
-    # 顧客IDを事前に作成して、それを取得する場合はこちらのコードを使用する
-    @customer.cards.create(card:@token_id)
-  end
-
 
 end

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,7 +1,7 @@
 = render 'signup/registration-header'
 .registration__container
   .registration__title 支払い方法
-  = form_with  url:credit_cards_path,class:'registration__content',id:'new_credit_card' do |f|
+  = form_with url:credit_cards_path,class:'registration__content',id:"new_credit_card",remote:true do |f|
     .registration__content__box
       = render 'render/input-form-required',label:'カード番号',example:'半角数字のみ',form: f, name: :number
       = image_tag 'credit_card.jpg'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,5 +8,6 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     %link{ href: "https://use.fontawesome.com/releases/v5.6.1/css/all.css", rel: "stylesheet"}/
+    %script{src:"https://js.pay.jp/", type:"text/javascript"}
   %body
     = yield

--- a/spec/factories/purchase.rb
+++ b/spec/factories/purchase.rb
@@ -1,31 +1,31 @@
-# require 'payjp'
-# Payjp.api_key=Rails.application.credentials.payjp_secret_key
-# token = Payjp::Token.create({
-#   :card => {
-#     :number => '4242424242424242',
-#     :cvc => '123',
-#     :exp_month => '2',
-#     :exp_year => '2020'
-#   }},
-#   {
-#     'X-Payjp-Direct-Token-Generate': 'true'
-#   } 
-# )
-# customer = Payjp::Customer.create()
-# customer.cards.create(card:token.id)
-# charge = Payjp::Charge.create(
-#   amount: 1000,
-#   customer: customer.id,
-#   currency: 'jpy',
-# )
-# purchase_id = charge.id
-# FactoryBot.define do
-#   factory :purchase do
-#     purchase_id           {purchase_id}
-#     evaluation            {1}
-#     association           :product
-#     association           :user
-#     created_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
-#     updated_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
-#   end
-# end
+require 'payjp'
+Payjp.api_key=Rails.application.credentials.payjp_secret_key
+token = Payjp::Token.create({
+  :card => {
+    :number => '4242424242424242',
+    :cvc => '123',
+    :exp_month => '2',
+    :exp_year => '2020'
+  }},
+  {
+    'X-Payjp-Direct-Token-Generate': 'true'
+  } 
+)
+customer = Payjp::Customer.create()
+customer.cards.create(card:token.id)
+charge = Payjp::Charge.create(
+  amount: 1000,
+  customer: customer.id,
+  currency: 'jpy',
+)
+purchase_id = charge.id
+FactoryBot.define do
+  factory :purchase do
+    purchase_id           {purchase_id}
+    evaluation            {1}
+    association           :product
+    association           :user
+    created_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
+    updated_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
+  end
+end

--- a/spec/factories/purchase.rb
+++ b/spec/factories/purchase.rb
@@ -1,31 +1,31 @@
-require 'payjp'
-Payjp.api_key=Rails.application.credentials.payjp_secret_key
-token = Payjp::Token.create({
-  :card => {
-    :number => '4242424242424242',
-    :cvc => '123',
-    :exp_month => '2',
-    :exp_year => '2020'
-  }},
-  {
-    'X-Payjp-Direct-Token-Generate': 'true'
-  } 
-)
-customer = Payjp::Customer.create()
-customer.cards.create(card:token.id)
-charge = Payjp::Charge.create(
-  amount: 1000,
-  customer: customer.id,
-  currency: 'jpy',
-)
-purchase_id = charge.id
-FactoryBot.define do
-  factory :purchase do
-    purchase_id           {purchase_id}
-    evaluation            {1}
-    association           :product
-    association           :user
-    created_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
-    updated_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
-  end
-end
+# require 'payjp'
+# Payjp.api_key=Rails.application.credentials.payjp_secret_key
+# token = Payjp::Token.create({
+#   :card => {
+#     :number => '4242424242424242',
+#     :cvc => '123',
+#     :exp_month => '2',
+#     :exp_year => '2020'
+#   }},
+#   {
+#     'X-Payjp-Direct-Token-Generate': 'true'
+#   } 
+# )
+# customer = Payjp::Customer.create()
+# customer.cards.create(card:token.id)
+# charge = Payjp::Charge.create(
+#   amount: 1000,
+#   customer: customer.id,
+#   currency: 'jpy',
+# )
+# purchase_id = charge.id
+# FactoryBot.define do
+#   factory :purchase do
+#     purchase_id           {purchase_id}
+#     evaluation            {1}
+#     association           :product
+#     association           :user
+#     created_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
+#     updated_at { Faker::Time.between(from: DateTime.now - 2, to: DateTime.now) }
+#   end
+# end


### PR DESCRIPTION
# WHY
クレジットカードの番号等を、ec2のサイトに送ることが禁止されたので、非同期通信でトークンを作成して送信するようにしたい。

# WHAT
- scriptタグにpayjp jsを使用する記述を行った。
- purchase.jsにて、クレジットカード登録を非同期で行う。またカードのトークン作成後には、入力フォームを空にして、paramsに情報が入らないようにした。