### PR TITLE
新規会員登録のクレジットカード登録の時もイベント発火するように設定。

### DIFF
--- a/app/assets/javascripts/purchase.js
+++ b/app/assets/javascripts/purchase.js
@@ -1,5 +1,5 @@
 $(document).on('turbolinks:load', function() {
-  $(".registration__content mypage__content").submit(function(e){
+  $("#new_credit_card, .registration__content mypage__content").submit(function(e){
     e.preventDefault();
     Payjp.setPublicKey('pk_test_d7948e7275630f3552910c45');
     var card = {

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -18,6 +18,7 @@ class CreditCardsController < ApplicationController
     # 顧客IDを事前に作成して、それを取得する場合はこちらのコードを使用する
     current_user.customer_id = @customer.id
     current_user.save
+    @customer.cards.create(card: params[:token])
     CreditCard.create(token_id: params[:token], user_id: current_user.id)
   end
 


### PR DESCRIPTION
# WHAT
- イベントの発火を追加して、新規会員登録時のカード登録のエラーを解決。