### PR TITLE
非同期通信の際のエラー修正

### DIFF
--- a/app/controllers/api/top_controller.rb
+++ b/app/controllers/api/top_controller.rb
@@ -1,4 +1,4 @@
-class Api::TopController < ApplicationController
+class Api::TopController < TopController
   def index
     if params[:parent_id] != nil
       parent_id = params[:parent_id].to_i

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,9 +1,8 @@
 class TopController < ApplicationController
-  skip_before_action :authenticate_user!,only:[:index,:show]
   before_action :big_categories
+  skip_before_action :authenticate_user!,only:[:index,:show]
   before_action :ransack_model
   def index
-    @bigcategories = Category.where(parent_id:nil, child_id:nil)
     @products = @bigcategories.map do |category|
       Product.where(category_grandparent_id: category.id).slice(0,4)
     end  


### PR DESCRIPTION
# WHAT
- ユーザーのサインイン確認が、ヘッダーの非同期通信の際にも働いてしまって、予期しない挙動をしていたので修正した。