### PR TITLE
商品が売り切れの場合は購入ボタンを表示しない

### DIFF
--- a/app/assets/stylesheets/products/products-detail.scss
+++ b/app/assets/stylesheets/products/products-detail.scss
@@ -109,6 +109,16 @@
         color: #fff;
       }
   }
+  &__sold-out__button {
+    background-color: #aaa;
+    width: 85%;
+    height: 60px;
+    margin: 0 auto;
+    font-size: 25px;
+    color: #fff;
+    text-align: center;
+    line-height: 60px;
+  }
     &__comment {
       margin: 30px;
       font-size: 18px;

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -78,8 +78,12 @@
         (税込)
       .item-detail__shipping_cost
         送料込み
-    .item-detail__purchase-button
-      = link_to '購入画面に進む',  new_product_purchase_path(@product.id)
+    - if @product.purchase_status_id == 1
+      .item-detail__purchase-button
+        = link_to '購入画面に進む',  new_product_purchase_path(@product.id)
+    - else
+      .item-detail__sold-out__button
+        売り切れました
     .item-detail__comment
       = @product.description
     .item-detail__like-bad-other


### PR DESCRIPTION
#WHAT
商品が売り切れの場合は購入ボタンを表示しない
#WHY
売り切れで在庫のない商品の購入を防ぐため